### PR TITLE
UPDATE: search api integration format

### DIFF
--- a/src/APIs/serpapi.ts
+++ b/src/APIs/serpapi.ts
@@ -29,6 +29,8 @@ async function searchGoogleUsingSerpapi(term: string) {
 }
 
 function parseSearchResults(stringResult: Promise<any>): string | undefined {
+  // @TODO -- create a parser to standardize results
+
   return undefined;
 }
 

--- a/src/APIs/serpapi.ts
+++ b/src/APIs/serpapi.ts
@@ -1,0 +1,35 @@
+import axios from "axios";
+import * as fs from "fs";
+import { promisify } from "util";
+import config from "./../config";
+
+async function searchGoogleUsingSerpapi(term: string) {
+  var answers;
+
+  var googleGetInstace = axios.create({
+    baseURL: "https://serpapi.com",
+    method: "GET",
+  });
+
+  term += " site: stackoverflow.com";
+
+  try {
+    answers = await googleGetInstace.get("/search", {
+      params: {
+        engine: "google",
+        q: term,
+        api_key: config.serpApiKey,
+      },
+    });
+  } catch (e) {
+    console.error(e);
+  }
+
+  return answers;
+}
+
+function parseSearchResults(stringResult: Promise<any>): string | undefined {
+  return undefined;
+}
+
+export default searchGoogleUsingSerpapi;

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,10 +5,12 @@ dotenv.config();
 
 interface IConfig {
   discordBotToken: string | undefined;
+  serpApiKey: string | undefined;
 }
 
 const config: IConfig = {
   discordBotToken: process.env.DISCORD_BOT_TOKEN,
+  serpApiKey: process.env.SERPAPI_KEY,
 };
 
 export default config;

--- a/src/utils/apiJunction.ts
+++ b/src/utils/apiJunction.ts
@@ -1,0 +1,77 @@
+import { promisify } from "util";
+import * as fs from "fs";
+import * as path from "path";
+import searchGoogleUsingSerpapi from "../APIs/serpapi";
+
+// types and interfaces
+interface globalApiRequestCounterInterface {
+  globalApiRequestCounter: number;
+}
+
+// TODO: standard result interface which all serpapi should follow while parsing data
+interface results {}
+
+var writeFile = promisify(fs.writeFile);
+var readFile = promisify(fs.readFile);
+var counterFilePath = path.resolve("./globalCounter.json");
+
+var globalApiRequestCounter: number = 0;
+
+initializeTheCounter().then(function (res) {
+  if (res !== undefined) {
+    globalApiRequestCounter = res;
+  }
+});
+
+export async function initializeTheCounter() {
+  try {
+    var data: string | globalApiRequestCounterInterface = await readFile(counterFilePath, {
+      encoding: "utf-8",
+    });
+    data = JSON.parse(data) as globalApiRequestCounterInterface;
+    return data.globalApiRequestCounter;
+  } catch (error) {
+    console.error(error);
+    await writeFile(counterFilePath, JSON.stringify({ globalApiRequestCounter: 0 }, null, 2));
+  }
+  return undefined;
+}
+
+async function search(term: string) {
+  try {
+    globalApiRequestCounter += 1;
+    writeFile(counterFilePath, JSON.stringify({ globalApiRequestCounter }, null, 2));
+  } catch (e) {
+    console.error(e);
+  }
+
+  try {
+    // TODO: assign the standard results interface
+    // var results:;
+    if (globalApiRequestCounter < 100) {
+      var results = await searchGoogleUsingSerpapi(term);
+    }
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+// async function axios_get() {
+//   var getInstance = axios.create({
+//     baseURL: "https://api.stackexchange.com/2.3",
+//     method: "GET",
+//   });
+
+//   var answers = await getInstance.get("/questions", {
+//     params: {
+//       site: "stackoverflow",
+//       sort: "activity",
+//       order: "desc",
+//     },
+//   });
+//   var data = answers.data as JSON;
+//   var stringData = JSON.stringify(data, null, 2);
+
+// }
+
+// export default { axios_get };

--- a/src/utils/globalCounter.json
+++ b/src/utils/globalCounter.json
@@ -1,0 +1,3 @@
+{
+  "globalApiRequestCounter": 0
+}


### PR DESCRIPTION
I want to run this idea of integrating different SERPAPIs.

The `APIs` folder will contain a different file for searching a specific API and returning parsed results which adhere to a specific format. We'd have a `utils` directory which will contain a `apiJunction.ts` file which will integrate all the SERPAPIs and will contain the standard search function which can be called to get results without worrying about different APIs. Finally, a counter file which will keep a record of global api request counter which will switch across different SERPAPIs when the request numbers cross their respective limitations.

What do you think about this?